### PR TITLE
Update to work with Spacemacs 0.200.13

### DIFF
--- a/config.el
+++ b/config.el
@@ -10,8 +10,8 @@
 ;;
 ;;; License: GPLv3
 
-;; (spacemacs|defvar-company-backends python-mode)
-;; (spacemacs|defvar-company-backends inferior-python-mode)
+(spacemacs|defvar-company-backends python-mode)
+(spacemacs|defvar-company-backends inferior-python-mode)
 ;; (spacemacs|defvar-company-backends pip-requirements-mode)
 
 ;; (spacemacs|define-jump-handlers python-mode)

--- a/packages.el
+++ b/packages.el
@@ -130,13 +130,12 @@
     ))
 
 (defun elpy/post-init-company ()
-  (spacemacs|add-company-backends
-    :backends (company-capf company-files)
-    :modes inferior-python-mode
-    :variables
-    company-minimum-prefix-length 0
-    company-idle-delay 0.5)
-  )
+  (spacemacs|add-company-hook python-mode)
+  (spacemacs|add-company-hook inferior-python-mode)
+  (push '(company-files company-capf) company-backends-inferior-python-mode)
+  (add-hook 'inferior-python-mode-hook (lambda ()
+                                         (setq-local company-minimum-prefix-length 0)
+                                         (setq-local company-idle-delay 0.5))))
 
 (defun elpy/post-init-counsel-gtags ()
   (spacemacs/counsel-gtags-define-keys-for-mode 'python-mode))


### PR DESCRIPTION
When I tried using this with Spacemacs 0.200.13, I ran into an issue with `spacemacs|add-company-backends` not being defined.

Running `emacs --debug-init` produces the following:

     Debugger entered--Lisp error: (void-function spacemacs|add-company-backends)
      (spacemacs|add-company-backends :backends (company-capf company-files) :modes inferior-python-mode :variables company-minimum-prefix-length 0 company-idle-delay 0.5)
      elpy/post-init-company()
      funcall(elpy/post-init-company)
      (condition-case err (funcall (intern (format "%S/post-init-%S" layer pkg-name))) ((debug quote error) (configuration-layer//increment-error-count) (spacemacs-buffer/append (format (concat "\nAn error occurred while post-configuring %S " "in layer %S (error: %s)\n") pkg-name layer err))))
      (if (not (configuration-layer//package-enabled-p pkg layer)) (spacemacs-buffer/message (format "  -> ignored post-init (%S)..." layer)) (spacemacs-buffer/message (format "  -> post-init (%S)..." layer)) (condition-case err (funcall (intern (format "%S/post-init-%S" layer pkg-name))) ((debug quote error) (configuration-layer//increment-error-count) (spacemacs-buffer/append (format (concat "\nAn error occurred while post-configuring %S " "in layer %S (error: %s)\n") pkg-name layer err)))))
      (progn (if (not (configuration-layer//package-enabled-p pkg layer)) (spacemacs-buffer/message (format "  -> ignored post-init (%S)..." layer)) (spacemacs-buffer/message (format "  -> post-init (%S)..." layer)) (condition-case err (funcall (intern (format "%S/post-init-%S" layer pkg-name))) ((debug quote error) (configuration-layer//increment-error-count) (spacemacs-buffer/append (format (concat "\nAn error occurred while post-configuring %S " "in layer %S (error: %s)\n") pkg-name layer err))))))
      (if (configuration-layer/layer-usedp layer) (progn (if (not (configuration-layer//package-enabled-p pkg layer)) (spacemacs-buffer/message (format "  -> ignored post-init (%S)..." layer)) (spacemacs-buffer/message (format "  -> post-init (%S)..." layer)) (condition-case err (funcall (intern (format "%S/post-init-%S" layer pkg-name))) ((debug quote error) (configuration-layer//increment-error-count) (spacemacs-buffer/append (format (concat "\nAn error occurred while post-configuring %S " "in layer %S (error: %s)\n") pkg-name layer err)))))))
      (lambda (layer) (if (configuration-layer/layer-usedp layer) (progn (if (not (configuration-layer//package-enabled-p pkg layer)) (spacemacs-buffer/message (format "  -> ignored post-init (%S)..." layer)) (spacemacs-buffer/message (format "  -> post-init (%S)..." layer)) (condition-case err (funcall (intern (format "%S/post-init-%S" layer pkg-name))) ((debug quote error) (configuration-layer//increment-error-count) (spacemacs-buffer/append (format ... pkg-name layer err))))))))(elpy)
      mapc((lambda (layer) (if (configuration-layer/layer-usedp layer) (progn (if (not (configuration-layer//package-enabled-p pkg layer)) (spacemacs-buffer/message (format "  -> ignored post-init (%S)..." layer)) (spacemacs-buffer/message (format "  -> post-init (%S)..." layer)) (condition-case err (funcall (intern (format "%S/post-init-%S" layer pkg-name))) ((debug quote error) (configuration-layer//increment-error-count) (spacemacs-buffer/append (format ... pkg-name layer err)))))))) (yaml typescript markdown latex javascript html emacs-lisp elpy c-c++))
      (let* ((pkg-name (eieio-oref pkg (quote :name))) (owner (car (eieio-oref pkg (quote :owners))))) (spacemacs-buffer/message (format "Configuring %S..." pkg-name)) (mapc (function (lambda (layer) (if (configuration-layer/layer-usedp layer) (progn (if (not ...) (spacemacs-buffer/message ...) (spacemacs-buffer/message ...) (condition-case err ... ...)))))) (eieio-oref pkg (quote :pre-layers))) (spacemacs-buffer/message (format "  -> init (%S)..." owner)) (funcall (intern (format "%S/init-%S" owner pkg-name))) (mapc (function (lambda (layer) (if (configuration-layer/layer-usedp layer) (progn (if (not ...) (spacemacs-buffer/message ...) (spacemacs-buffer/message ...) (condition-case err ... ...)))))) (eieio-oref pkg (quote :post-layers))))
      configuration-layer//configure-package([eieio-class-tag--cfgl-package company nil (auto-completion) (keyboard-layout) (yaml typescript markdown latex javascript html emacs-lisp elpy c-c++) elpa t nil nil nil nil])
      (cond ((eq (quote dotfile) (car (eieio-oref pkg (quote :owners)))) (spacemacs-buffer/message (format "%S is configured in the dotfile." pkg-name))) (t (configuration-layer//configure-package pkg)))
      (cond ((eieio-oref pkg (quote :lazy-install)) (spacemacs-buffer/message (format "%S ignored since it can be lazily installed." pkg-name))) ((and (eieio-oref pkg (quote :excluded)) (not (eieio-oref pkg (quote :protected)))) (spacemacs-buffer/message (format "%S ignored since it has been excluded." pkg-name))) ((null (eieio-oref pkg (quote :owners))) (spacemacs-buffer/message (format "%S ignored since it has no owner layer." pkg-name))) ((not (cfgl-package-enabledp pkg)) (spacemacs-buffer/message (format "%S is toggled off." pkg-name))) (t (let ((location (eieio-oref pkg (quote :location)))) (cond ((stringp location) (if (file-directory-p location) (setq load-path (cons ... load-path)) (configuration-layer//warning "Location path for package %S does not exists (value: %s)." pkg location))) ((and (eq (quote local) location) (eq (quote dotfile) (car ...))) (setq load-path (cons (file-name-as-directory ...) load-path))) ((eq (quote local) location) (let* ((owner ...) (dir ...)) (setq load-path (cons ... load-path)))))) (if (memq (eieio-oref pkg (quote :location)) (quote (local site built-in))) nil (configuration-layer//activate-package pkg-name)) (cond ((eq (quote dotfile) (car (eieio-oref pkg (quote :owners)))) (spacemacs-buffer/message (format "%S is configured in the dotfile." pkg-name))) (t (configuration-layer//configure-package pkg)))))
      (let ((pkg (configuration-layer/get-package pkg-name))) (cond ((eieio-oref pkg (quote :lazy-install)) (spacemacs-buffer/message (format "%S ignored since it can be lazily installed." pkg-name))) ((and (eieio-oref pkg (quote :excluded)) (not (eieio-oref pkg (quote :protected)))) (spacemacs-buffer/message (format "%S ignored since it has been excluded." pkg-name))) ((null (eieio-oref pkg (quote :owners))) (spacemacs-buffer/message (format "%S ignored since it has no owner layer." pkg-name))) ((not (cfgl-package-enabledp pkg)) (spacemacs-buffer/message (format "%S is toggled off." pkg-name))) (t (let ((location (eieio-oref pkg (quote :location)))) (cond ((stringp location) (if (file-directory-p location) (setq load-path ...) (configuration-layer//warning "Location path for package %S does not exists (value: %s)." pkg location))) ((and (eq ... location) (eq ... ...)) (setq load-path (cons ... load-path))) ((eq (quote local) location) (let* (... ...) (setq load-path ...))))) (if (memq (eieio-oref pkg (quote :location)) (quote (local site built-in))) nil (configuration-layer//activate-package pkg-name)) (cond ((eq (quote dotfile) (car (eieio-oref pkg ...))) (spacemacs-buffer/message (format "%S is configured in the dotfile." pkg-name))) (t (configuration-layer//configure-package pkg))))))
      (while --dolist-tail-- (setq pkg-name (car --dolist-tail--)) (spacemacs-buffer/loading-animation) (let ((pkg (configuration-layer/get-package pkg-name))) (cond ((eieio-oref pkg (quote :lazy-install)) (spacemacs-buffer/message (format "%S ignored since it can be lazily installed." pkg-name))) ((and (eieio-oref pkg (quote :excluded)) (not (eieio-oref pkg (quote :protected)))) (spacemacs-buffer/message (format "%S ignored since it has been excluded." pkg-name))) ((null (eieio-oref pkg (quote :owners))) (spacemacs-buffer/message (format "%S ignored since it has no owner layer." pkg-name))) ((not (cfgl-package-enabledp pkg)) (spacemacs-buffer/message (format "%S is toggled off." pkg-name))) (t (let ((location (eieio-oref pkg ...))) (cond ((stringp location) (if ... ... ...)) ((and ... ...) (setq load-path ...)) ((eq ... location) (let* ... ...)))) (if (memq (eieio-oref pkg (quote :location)) (quote (local site built-in))) nil (configuration-layer//activate-package pkg-name)) (cond ((eq (quote dotfile) (car ...)) (spacemacs-buffer/message (format "%S is configured in the dotfile." pkg-name))) (t (configuration-layer//configure-package pkg)))))) (setq --dolist-tail-- (cdr --dolist-tail--)))
      (let ((--dolist-tail-- packages) pkg-name) (while --dolist-tail-- (setq pkg-name (car --dolist-tail--)) (spacemacs-buffer/loading-animation) (let ((pkg (configuration-layer/get-package pkg-name))) (cond ((eieio-oref pkg (quote :lazy-install)) (spacemacs-buffer/message (format "%S ignored since it can be lazily installed." pkg-name))) ((and (eieio-oref pkg (quote :excluded)) (not (eieio-oref pkg ...))) (spacemacs-buffer/message (format "%S ignored since it has been excluded." pkg-name))) ((null (eieio-oref pkg (quote :owners))) (spacemacs-buffer/message (format "%S ignored since it has no owner layer." pkg-name))) ((not (cfgl-package-enabledp pkg)) (spacemacs-buffer/message (format "%S is toggled off." pkg-name))) (t (let ((location ...)) (cond (... ...) (... ...) (... ...))) (if (memq (eieio-oref pkg ...) (quote ...)) nil (configuration-layer//activate-package pkg-name)) (cond ((eq ... ...) (spacemacs-buffer/message ...)) (t (configuration-layer//configure-package pkg)))))) (setq --dolist-tail-- (cdr --dolist-tail--))))
      configuration-layer//configure-packages-2((abbrev ac-ispell ace-jump-helm-line ace-link ace-window adaptive-wrap aggressive-indent all-the-icons ansi-colors archive-mode auctex auctex-latexmk auto-compile auto-complete auto-dictionary auto-highlight-symbol auto-yasnippet avy bookmark bracketed-paste cc-mode centered-buffer-mode centered-cursor clang-format clean-aindent-mode cmake-mode coffee-mode column-enforce-mode company company-auctex company-c-headers company-quickhelp company-statistics company-tern company-web company-ycmd conf-mode css-mode cython-mode dactyl-mode debug default-helm-config default-ivy-config default-org-config define-word desktop diff-hl diff-mode dired dired-x ...))
      configuration-layer//configure-packages((abbrev ac-ispell ace-jump-helm-line ace-link ace-window adaptive-wrap aggressive-indent all-the-icons ansi-colors archive-mode async auctex auctex-latexmk auto-compile auto-complete auto-dictionary auto-highlight-symbol auto-yasnippet avy bind-key bind-map bookmark bracketed-paste cc-mode centered-buffer-mode centered-cursor clang-format clean-aindent-mode cmake-mode coffee-mode column-enforce-mode company company-auctex company-c-headers company-quickhelp company-statistics company-tern company-web company-ycmd conf-mode css-mode cython-mode dactyl-mode debug default-helm-config default-ivy-config default-org-config define-word desktop diff-hl ...))
      configuration-layer/sync()
      (if (not (version<= spacemacs-emacs-min-version emacs-version)) (error (concat "Your version of Emacs (%s) is too old. " "Spacemacs requires Emacs version %s or above.") emacs-version spacemacs-emacs-min-version) (load-file (concat (file-name-directory load-file-name) "core/core-load-paths.el")) (require (quote core-spacemacs)) (spacemacs/init) (configuration-layer/sync) (spacemacs-buffer/display-startup-note) (spacemacs/setup-startup-hook) (require (quote server)) (if (server-running-p) nil (server-start)))
      eval-buffer(#<buffer  *load*> nil "/home/rdp/.emacs.d/init.el" nil t)  ; Reading at buffer position 1264
      load-with-code-conversion("/home/rdp/.emacs.d/init.el" "/home/rdp/.emacs.d/init.el" t t)
      load("/home/rdp/.emacs.d/init" t t)
      #[0 "\205\266	\306=\203\307\310Q\202?	\311=\204\307\312Q\202?\313\307\314\315#\203*\316\202?\313\307\314\317#\203>\320\321\322!D\nB\323\202?\316\324\325\324\211#\210\324=\203e\326\327\330\307\331Q!\"\325\324\211#\210\324=\203d\210\203\247\332!\333\232\203\247\334!\211\335P\336!\203\201\211\202\214\336!\203\213\202\214\314\262\203\245\337\"\203\243\340\341#\210\342\343!\210\266\f?\205\264\314\325\344\324\211#)\262\207" [init-file-user system-type delayed-warnings-list user-init-file inhibit-default-init inhibit-startup-screen ms-dos "~" "/_emacs" windows-nt "/.emacs" directory-files nil "^\\.emacs\\(\\.elc?\\)?$" "~/.emacs" "^_emacs\\(\\.elc?\\)?$" initialization format-message "`_emacs' init file is deprecated, please use `.emacs'" "~/_emacs" t load expand-file-name "init" file-name-as-directory "/.emacs.d" file-name-extension "elc" file-name-sans-extension ".el" file-exists-p file-newer-than-file-p message "Warning: %s is newer than %s" sit-for 1 "default"] 7]()
      command-line()
      normal-top-level()

This request replaces that call with explicit hooks and backend variable definitions like the ones currently used by the official Python layer.